### PR TITLE
Update zmnotify.py

### DIFF
--- a/zmnotify.py
+++ b/zmnotify.py
@@ -377,6 +377,9 @@ class ZmEventNotifier(hass.Hass):
         self.occupied_state = self.get_state(occupied_bool)
         self.listen_state(self.handle_occupied_state_change, occupied_bool)
         self.log("{} is currently {}".format(occupied_bool, self.occupied_state))
+        if self.occupied_state == 'on':
+           self.notify_list = self.notify_occup_list
+           self.occupied_state = True
 
         # sensors is a dict of sensorid with associated notify gate
         for sensor in self.args["sensors"]:


### PR DESCRIPTION
This fixes a two layer bug. If the app initializes wit the occupied bool set to true (in other-words I am home) the state of the bool is grabbed as a string 'on' rather than True or False. Further, no check is performed to see if I am home so it defaults to unoccupied until I toggle the bool in HA. So I added a simple if statement to fix that.